### PR TITLE
Bug fix: incorrect heartbeat rates in some cases

### DIFF
--- a/algorithm_by_RF.h
+++ b/algorithm_by_RF.h
@@ -48,13 +48,9 @@
 // The sum is symmetrc, so you can evaluate it by multiplying its positive half by 2. It is precalcuated here for enhanced 
 // performance.
 const float sum_X2 = 83325; // WARNING: you MUST recalculate this sum if you changed either ST or FS above!
-#define MAX_HR 125  // Maximal heart rate. To eliminate erroneous signals, calculated HR should never be greater than this number.
+// WARNING: The two parameters below are CRUCIAL! Proper HR evaluation depends on these.
+#define MAX_HR 180  // Maximal heart rate. To eliminate erroneous signals, calculated HR should never be greater than this number.
 #define MIN_HR 40   // Minimal heart rate. To eliminate erroneous signals, calculated HR should never be lower than this number.
-// Typical heart rate. Set it to the upper value of the expected heart rate range in a given application. Obviously, it must be 
-// in between MIN_HR and MAX_HR. For example, if HR in an overnight measurement varies between 46 and 65, but 90% of the time 
-// stays between 50 and 60, then set it to 60.
-// WARNING: This is a CRUCIAL parameter! Proper HR evaluation depends on it.
-#define TYPICAL_HR 60
 // Minimal ratio of two autocorrelation sequence elements: one at a considered lag to the one at lag 0.
 // Good quality signals must have such ratio greater than this minimum.
 const float min_autocorrelation_ratio = 0.5;
@@ -71,7 +67,6 @@ const int32_t BUFFER_SIZE = FS*ST; // Number of smaples in a single batch
 const int32_t FS60 = FS*60;  // Conversion factor for heart rate from bps to bpm
 const int32_t LOWEST_PERIOD = FS60/MAX_HR; // Minimal distance between peaks
 const int32_t HIGHEST_PERIOD = FS60/MIN_HR; // Maximal distance between peaks
-const int32_t INIT_INTERVAL = FS60/TYPICAL_HR; // Seed value for heart rate determination routine
 const float mean_X = (float)(BUFFER_SIZE-1)/2.0; // Mean value of the set of integers from 0 to BUFFER_SIZE-1. For ST=4 and FS=25 it's equal to 49.5.
 
 void rf_heart_rate_and_oxygen_saturation(uint32_t *pun_ir_buffer, int32_t n_ir_buffer_length, uint32_t *pun_red_buffer, float *pn_spo2, int8_t *pch_spo2_valid, int32_t *pn_heart_rate, 
@@ -80,6 +75,7 @@ float rf_linear_regression_beta(float *pn_x, float xmean, float sum_x2);
 float rf_autocorrelation(float *pn_x, int32_t n_size, int32_t n_lag);
 float rf_rms(float *pn_x, int32_t n_size, float *sumsq);
 float rf_Pcorrelation(float *pn_x, float *pn_y, int32_t n_size);
+void rf_initialize_periodicity_search(float *pn_x, int32_t n_size, int32_t *p_last_periodicity, int32_t n_max_distance, float min_aut_ratio, float aut_lag0);
 void rf_signal_periodicity(float *pn_x, int32_t n_size, int32_t *p_last_periodicity, int32_t n_min_distance, int32_t n_max_distance, float min_aut_ratio, float aut_lag0, float *ratio);
 
 #endif /* ALGORITHM_BY_RF_H_ */


### PR DESCRIPTION
When the actual heart rate (HR) was at least twice higher than TYPICAL_HR, the algorithm was reporting only 50% of it. This is beacuse the second, not the first, autocorrelation peak was being chosen.