### PR TITLE
Small change to facilitate compilation in a Linux box

### DIFF
--- a/algorithm.cpp
+++ b/algorithm.cpp
@@ -58,7 +58,7 @@
 */
 
 #include "algorithm.h"
-#include "arduino.h"
+#include "Arduino.h"
 
 //#if defined(ARDUINO_AVR_UNO)
 //Arduino Uno doesn't have enough SRAM to store 100 samples of IR led data and red led data in 32-bit format

--- a/algorithm.h
+++ b/algorithm.h
@@ -61,7 +61,7 @@
 */
 #ifndef ALGORITHM_H_
 #define ALGORITHM_H_
-#include <arduino.h>
+#include <Arduino.h>
 
 #define true 1
 #define false 0

--- a/algorithm_by_RF.h
+++ b/algorithm_by_RF.h
@@ -33,7 +33,7 @@
 */
 #ifndef ALGORITHM_BY_RF_H_
 #define ALGORITHM_BY_RF_H_
-#include <arduino.h>
+#include <Arduino.h>
 
 /*
  * Settable parameters 

--- a/max30102.h
+++ b/max30102.h
@@ -63,7 +63,7 @@
 #ifndef MAX30102_H_
 #define MAX30102_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 //#define I2C_WRITE_ADDR 0xAE
 //#define I2C_READ_ADDR 0xAF
 #define I2C_WRITE_ADDR 0x57 // 7-bit version of the above


### PR DESCRIPTION
I am currently testing this code in an Arduino Nano 33 BLE (it has a Nordic nRF52480 MCU) and so far is working fine. Thank you very much for your work, it has been a life saver.

I am working on a Linux machine so I had a compilation problem with the "arduino.h" header file, the compiler could not find it. The easy fix is to change "arduino.h" to "Arduino.h" in every relevant file as the header name is actually "Arduino.h" and in case-sensitive Linux filesystems this matters. I saw in some of the closed issues that some users of this code encountered this problem so to help with a small contribution I propose this pull request that fixes this issue. This shouldn't have any negative effect on Windows systems.