### PR TITLE
Add comprehensive settings helper module with bitfield utilities for MAX30102

### DIFF
--- a/algorithm.cpp
+++ b/algorithm.cpp
@@ -87,10 +87,10 @@ void maxim_heart_rate_and_oxygen_saturation(uint32_t *pun_ir_buffer, int32_t n_i
 * \retval       None
 */
 {
-  uint32_t un_ir_mean,un_only_once ;
+  uint32_t un_ir_mean;
   int32_t k, n_i_ratio_count;
-  int32_t i, s, m, n_exact_ir_valley_locs_count, n_middle_idx;
-  int32_t n_th1, n_npks, n_c_min;   
+  int32_t i, n_exact_ir_valley_locs_count, n_middle_idx;
+  int32_t n_th1, n_npks;   
   int32_t an_ir_valley_locs[15] ;
   int32_t n_peak_interval_sum;
   static int32_t n_last_peak_interval=FS; // Initialize it to 25, which corresponds to heart rate of 60 bps, RF
@@ -101,8 +101,8 @@ void maxim_heart_rate_and_oxygen_saturation(uint32_t *pun_ir_buffer, int32_t n_i
   int32_t n_y_dc_max_idx, n_x_dc_max_idx; 
   int32_t an_ratio[5], n_ratio_average; 
   int32_t n_nume, n_denom ;
-  int32_t an_x[ BUFFER_SIZE]; //ir
-  int32_t an_y[ BUFFER_SIZE]; //red
+  int32_t an_x[BUFFER_SIZE]; //ir
+  int32_t an_y[BUFFER_SIZE]; //red
 
   // calculates DC mean and subtracts DC from ir
   un_ir_mean =0; 

--- a/max30102_settings.cpp
+++ b/max30102_settings.cpp
@@ -1,0 +1,185 @@
+
+#include "max30102_settings.h"
+#include "max30102.h"
+
+namespace{
+    /**
+     * \brief        Alter a specific bit in a register value
+     * \param[in]    reg     - register value
+     * \param[in]    bit     - bit position to alter
+     * \param[in]    value   - new value for the bit (true for 1, false for 0)
+     * \retval       new register value with the altered bit
+     */
+    uint8_t alterBitValue(uint8_t reg, uint8_t bit, bool value) {
+        if (value) 
+            return reg | (1 << bit);
+        else 
+            return reg & ~(1 << bit);
+    }
+
+    /**
+     * \brief        Set bits in a field of a register according to a mask
+     * \param[in]    regValue   - current register value
+     * \param[in]    value      - new value to set in the field
+     * \param[in]    mask       - mask to specify which bits to set
+     * \retval       new register value with the bits setted
+     */
+    uint8_t setBitsInField(uint8_t regValue, uint8_t value, uint8_t mask) {
+        return (regValue & ~mask) | (value & mask);
+    }
+
+    /**
+     * \brief        Check if a value fits in a mask
+     * \param[in]    value   - value to check
+     * \param[in]    mask    - mask to check against
+     * \retval       true if the value fits in the mask, false otherwise
+     */
+    bool checkValueInMask(uint8_t value, uint8_t mask) {
+        return (value & ~mask) == 0;
+    }
+
+    /**
+     * \brief        Change a specific bit in a register value
+     * \param[in]    regAddr   - register address
+     * \param[in]    bit       - bit position to change
+     * \param[in]    value     - new value for the bit (true for 1, false for 0)
+     * \retval       true on success, false on failure
+     */
+    bool changeRegBitValue(uint8_t regAddr, uint8_t bit, bool value) {
+        uint8_t actualRegValue;
+        maxim_max30102_read_reg(regAddr, &actualRegValue);
+        return maxim_max30102_write_reg(regAddr, alterBitValue(actualRegValue, bit, value));
+    }
+
+    /**
+     * \brief        Change a specific mask in a register value
+     * \param[in]    regAddr   - register address
+     * \param[in]    mask      - mask to change
+     * \param[in]    value     - new value for the mask
+     * \param[in]    doCheckValueInMask - whether to check if the value fits in the mask
+     * \retval       true on success, false on failure
+     */
+    bool changeRegMaskValue(uint8_t regAddr, uint8_t mask, uint8_t value, bool doCheckValueInMask = true) {
+        if (doCheckValueInMask && !checkValueInMask(value, mask)) 
+            return false;
+        
+
+        uint8_t actualRegValue;
+        maxim_max30102_read_reg(regAddr, &actualRegValue);
+        actualRegValue = setBitsInField(actualRegValue, value, mask);
+        return maxim_max30102_write_reg(regAddr, actualRegValue);
+    }
+}
+
+
+// Interrupts Enable 1
+// Reg: REG_INTR_ENABLE_1
+const uint8_t INTR_A_FULL_BIT = 7;
+const uint8_t INTR_PPG_RDY_BIT = 6;
+const uint8_t INTR_ALC_OVF_BIT = 5;
+
+bool interruptAFull(bool enable){
+    return changeRegBitValue(REG_INTR_ENABLE_1, INTR_A_FULL_BIT, enable);
+}
+bool interruptPPGReady(bool enable){
+    return changeRegBitValue(REG_INTR_ENABLE_1, INTR_PPG_RDY_BIT, enable);
+}
+bool interruptALCOverflow(bool enable){
+    return changeRegBitValue(REG_INTR_ENABLE_1, INTR_ALC_OVF_BIT, enable);
+}
+
+
+// Interrupts Enable 2
+// Reg: REG_INTR_ENABLE_2
+const uint8_t INTR_DIE_TEMP_RDY_BIT = 1;
+
+bool interruptDIETempReady(bool enable){
+    return changeRegBitValue(REG_INTR_ENABLE_2, INTR_DIE_TEMP_RDY_BIT, enable);
+}
+
+
+//FIFO
+// Reg: REG_FIFO_CONFIG
+const uint8_t FIFO_WR_PTR_MASK = 0x1F;
+const uint8_t FIFO_OVF_COUNTER_MASK = 0x1F;
+const uint8_t FIFO_RD_PTR_MASK = 0x1F;
+const uint8_t FIFO_DATA_MASK = 0xFF;
+
+bool setFifoWritePointer(uint8_t value) {
+    return changeRegMaskValue(REG_FIFO_WR_PTR, FIFO_WR_PTR_MASK, value);
+}
+bool setFifoOverflowCounter(uint8_t value) {
+    return changeRegMaskValue(REG_OVF_COUNTER, FIFO_OVF_COUNTER_MASK, value);
+}
+bool setFifoReadPointer(uint8_t value) {
+    return changeRegMaskValue(REG_FIFO_RD_PTR, FIFO_RD_PTR_MASK, value);
+}
+bool setFifoDataRegister(uint8_t value) {
+    return changeRegMaskValue(REG_FIFO_DATA, FIFO_DATA_MASK, value);
+}
+
+
+// FIFO Configuration
+// Reg: REG_FIFO_CONFIG
+const uint8_t FIFO_SAMPLE_AVERAGE_MASK = 0xE0;
+const uint8_t FIFO_ROLLOVER_EN_BIT = 4;
+const uint8_t FIFO_A_FULL_MASK = 0x0F;
+
+bool setSampleAveraging(SampleAveraging sampleAveraging){
+    return changeRegMaskValue(REG_FIFO_CONFIG, FIFO_SAMPLE_AVERAGE_MASK, sampleAveraging);
+}
+bool setFifoRollOverOnFull(bool enable){
+    return changeRegBitValue(REG_FIFO_CONFIG, FIFO_ROLLOVER_EN_BIT, enable);
+}
+bool setFifoAlmostFullThreshold(uint8_t threshold){
+    return changeRegMaskValue(REG_FIFO_CONFIG, FIFO_A_FULL_MASK, threshold);
+}
+
+// Mode Configuration
+// Reg: REG_MODE_CONFIG
+const uint8_t MODE_SHUTDOWN_BIT = 7;
+const uint8_t MODE_RESET_BIT = 6;
+const uint8_t MODE_MASK = 0x07; 
+
+bool setShutdownCtrl(bool enable){
+    return changeRegBitValue(REG_MODE_CONFIG, MODE_SHUTDOWN_BIT, enable);
+}
+bool setResetCtrl(bool enable){
+    return changeRegBitValue(REG_MODE_CONFIG, MODE_RESET_BIT, enable);
+}
+bool setModeControl(ModeControl mode){
+    return changeRegMaskValue(REG_MODE_CONFIG, MODE_MASK, mode);
+}
+
+// SPO2 Configuration
+// Reg: REG_SPO2_CONFIG
+const uint8_t SPO2_ADC_RANGE_MASK = 0x60;
+const uint8_t SPO2_SAMPLE_RATE_MASK = 0x1C;
+const uint8_t SPO2_PULSE_WIDTH_MASK = 0x03;
+
+bool setSPO2ADCRange(SPO2_ADC_Range range){
+    return changeRegMaskValue(REG_SPO2_CONFIG, SPO2_ADC_RANGE_MASK, range);
+}
+bool setSPO2SampleRate(SPO2_SampleRate rate){
+    return changeRegMaskValue(REG_SPO2_CONFIG, SPO2_SAMPLE_RATE_MASK, rate);
+}
+bool setSPO2PulseWidth(SPO2_PulseWidth width){
+    return changeRegMaskValue(REG_SPO2_CONFIG, SPO2_PULSE_WIDTH_MASK, width);
+}
+
+// LED Configuration
+// Reg: REG_LED1_PA, REG_LED2_PA
+const uint8_t LED_PA_MASK = 0xFF;
+bool setLED1PulseAmplitude(uint8_t amplitude){
+    return changeRegMaskValue(REG_LED1_PA, LED_PA_MASK, amplitude);
+}
+bool setLED2PulseAmplitude(uint8_t amplitude){
+    return changeRegMaskValue(REG_LED2_PA, LED_PA_MASK, amplitude);
+}
+
+// Temperature Configuration
+// Reg: REG_TEMP_CONFIG
+const uint8_t TEMP_EN_BIT = 0;
+bool setTemperatureEnabled(bool enable){
+    return changeRegBitValue(REG_TEMP_CONFIG, TEMP_EN_BIT, enable);
+}

--- a/max30102_settings.h
+++ b/max30102_settings.h
@@ -1,0 +1,221 @@
+/** \file max30102_settings.h ******************************************************
+ * 
+ * Project: MAXREFDES117#
+ * Filename: max30102_settings.h
+ * Description: This module allow to easily set the MAX30102 settings.
+ * All the settings are based on the MAX30102 datasheet that can be found
+ * at:
+ * https://www.analog.com/media/en/technical-documentation/data-sheets/max30102.pdf
+ * 
+ * Revision History:
+ * 20-04-2025 Rev 01.00 GL Initial release.
+ * 
+ */
+
+ #ifndef MAX30102_SETTINGS_H
+ #define MAX30102_SETTINGS_H
+ 
+ #include "Arduino.h"
+ 
+ #pragma region "Control Enumerations"
+ 
+ constexpr uint8_t bitToMask(uint8_t bitNumber, int value = 1) {
+     return static_cast<uint8_t>(value << bitNumber);
+ }
+ 
+ enum SampleAveraging : uint8_t{
+     NO_AVERAGING = bitToMask(7,0) | bitToMask(6,0) | bitToMask(5,0), // No averaging applied
+     AVG_2 =  bitToMask(7,0) | bitToMask(6,0) | bitToMask(5,1), // 2 samples averaged
+     AVG_4 =  bitToMask(7,0) | bitToMask(6,1) | bitToMask(5,0), // 4 samples averaged
+     AVG_8 =  bitToMask(7,0) | bitToMask(6,1) | bitToMask(5,1), // 8 samples averaged
+     AVG_16 = bitToMask(7,1) | bitToMask(6,0) | bitToMask(5,0), // 16 samples averaged
+     AVG_32 = bitToMask(7,1) | bitToMask(6,0) | bitToMask(5,1)  // 32 samples averaged
+ };
+ 
+ enum ModeControl : uint8_t {
+     HEART_RATE = bitToMask(2,0) | bitToMask(1,1) | bitToMask(0,0), // Heart Rate mode
+     SPO2 = bitToMask(2,0) | bitToMask(1,1) | bitToMask(0,1), // SpO2 mode
+     MULTI_LED = bitToMask(2,1) | bitToMask(1,1) | bitToMask(0,1), // Multi-LED mode
+ };
+ 
+ enum SPO2_ADC_Range: uint8_t{
+     ADC_RANGE_2048 = bitToMask(6,0) | bitToMask(5,0), // 2048nA
+     ADC_RANGE_4096 = bitToMask(6,0) | bitToMask(5,1), // 4096nA
+     ADC_RANGE_8192 = bitToMask(6,1) | bitToMask(5,0), // 8192nA
+     ADC_RANGE_16384 = bitToMask(6,1) | bitToMask(5,1) // 16384nA
+ };
+ 
+ enum SPO2_SampleRate: uint8_t{
+     SPO2_RATE_50 = bitToMask(4,0) | bitToMask(3,0) | bitToMask(2,0), // 50Hz
+     SPO2_RATE_100 = bitToMask(4,0) | bitToMask(3,0) | bitToMask(2,1), // 100Hz
+     SPO2_RATE_200 = bitToMask(4,0) | bitToMask(3,1) | bitToMask(2,0), // 200Hz
+     SPO2_RATE_400 = bitToMask(4,0) | bitToMask(3,1) | bitToMask(2,1), // 400Hz
+     SPO2_RATE_800 = bitToMask(4,1) | bitToMask(3,0) | bitToMask(2,0), // 800Hz
+     SPO2_RATE_1000 = bitToMask(4,1) | bitToMask(3,0) | bitToMask(2,1), // 1000Hz
+     SPO2_RATE_1600 = bitToMask(4,1) | bitToMask(3,1) | bitToMask(2,0), // 1600Hz
+     SPO2_RATE_3200 = bitToMask(4,1) | bitToMask(3,1) | bitToMask(2,1), // 3200Hz
+ };
+ 
+ enum SPO2_PulseWidth: uint8_t{
+     PW_69 = bitToMask(1,0) | bitToMask(0,0), // 69us - 15bits adc resolution
+     PW_118 = bitToMask(1,0) | bitToMask(0,1), // 118us - 16bits adc resolution
+     PW_215 = bitToMask(1,1) | bitToMask(0,0), // 215us - 17bits adc resolution
+     PW_411 = bitToMask(1,1) | bitToMask(0,1) // 411us - 18bits adc resolution
+ };
+ 
+ #pragma endregion
+ 
+ 
+ #pragma region "Interrupts Status (0x00-0x01)"
+ 
+ // Interrupts Status 1
+ /**
+  * \brief        Enable or disable the FIFO Almost Full interrupt
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool interruptAFull(bool enable);
+ /**
+  * \brief        Enable or disable the new FIFO data ready interrupt
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool interruptPPGReady(bool enable);
+ /**
+  * \brief        Enable or disable the Ambient Light Cancellation overflow interrupt
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool interruptALCOverflow(bool enable);
+ 
+ // Interrupts Status 2
+ /**
+  * \brief        Enable or disable the internal Temperature sensor ready interrupt
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool interruptDIETempReady(bool enable);
+ 
+ #pragma endregion
+ 
+ #pragma region "FIFO (0x04-0x07)"
+ /**
+  * \brief        Set the FIFO write pointer
+  * \param[in]    pointer FIFO write pointer value
+  * \retval       true on success, false on failure
+  */
+ bool setFifoWritePointer(uint8_t pointer);
+ /**
+  * \brief        Set the FIFO overflow counter
+  * \param[in]    counter FIFO overflow counter value
+  * \retval       true on success, false on failure
+  */
+ bool setFifoOverflowCounter(uint8_t counter);
+ /**
+  * \brief        Set the FIFO read pointer
+  * \param[in]    pointer FIFO read pointer value
+  * \retval       true on success, false on failure
+  */
+ bool setFifoReadPointer(uint8_t pointer);
+ /**
+  * \brief        Set the FIFO data register
+  * \param[in]    data FIFO data register value
+  * \retval       true on success, false on failure
+  */
+ bool setFifoDataRegister(uint8_t data);
+ 
+ #pragma endregion
+ 
+ #pragma region "FIFO Configuration (0x08)"
+ /**
+  * \brief        Set the sample averaging mode
+  * \param[in]    sampleAveraging Sample averaging mode
+  * \retval       true on success, false on failure
+  */
+ bool setSampleAveraging(SampleAveraging sampleAveraging);
+ /**
+  * \brief        Set the FIFO roll over on full
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool setFifoRollOverOnFull(bool enable);
+ /**
+  * \brief        Set the FIFO almost full threshold
+  * \param[in]    threshold FIFO almost full threshold value
+  * \retval       true on success, false on failure
+  */
+ bool setFifoAlmostFullThreshold(uint8_t threshold);
+ 
+ #pragma endregion
+ 
+ #pragma region "Mode Configuration (0x09)"
+ /**
+  * \brief        Set the shutdown control
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool setShutdownCtrl(bool enable);
+ /**
+  * \brief        Set the reset control
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool setResetCtrl(bool enable);
+ /**
+  * \brief        Set the mode control
+  * \param[in]    mode Mode control value
+  * \retval       true on success, false on failure
+  */
+ bool setModeControl(ModeControl modeControl);
+ 
+ #pragma endregion
+ 
+ #pragma region "SPO2 Configuration (0x0A)"
+ /**
+  * \brief        Set the ADC range
+  * \param[in]    adcRange ADC range value
+  * \retval       true on success, false on failure
+  */
+ bool setSPO2ADCRange(SPO2_ADC_Range adcRange);
+ /**
+  * \brief        Set the sample rate
+  * \param[in]    sampleRate Sample rate value
+  * \retval       true on success, false on failure
+  */
+ bool setSPO2SampleRate(SPO2_SampleRate sampleRate);
+ /**
+  * \brief        Set the pulse width
+  * \param[in]    pulseWidth Pulse width value
+  * \retval       true on success, false on failure
+  */
+ bool setSPO2PulseWidth(SPO2_PulseWidth pulseWidth);
+ 
+ #pragma endregion
+ 
+ #pragma region "LED Pulse Amplitude (0x0C-0x0D)"
+ /**
+  * \brief        Set the LED1 pulse amplitude
+  * \param[in]    amplitude LED1 pulse amplitude value
+  * \retval       true on success, false on failure
+  */
+ bool setLED1PulseAmplitude(uint8_t amplitude);
+ /**
+  * \brief        Set the LED2 pulse amplitude
+  * \param[in]    amplitude LED2 pulse amplitude value
+  * \retval       true on success, false on failure
+  */
+ bool setLED2PulseAmplitude(uint8_t amplitude);
+ 
+ #pragma endregion
+ 
+ #pragma region "Temperature Data (0x1F-0x21)"
+ /**
+  * \brief        Set the temperature enabled
+  * \param[in]    enable true to enable, false to disable
+  * \retval       true on success, false on failure
+  */
+ bool setTemperatureEnabled(bool enable);
+ 
+ #pragma endregion
+ 
+ #endif

--- a/max30102_settings_TESTER.cpp
+++ b/max30102_settings_TESTER.cpp
@@ -1,0 +1,130 @@
+#include "max30102_settings.h"
+#include "max30102.h"
+
+namespace
+{
+    template<typename Func, typename ParamType>
+    
+    /**
+     * \brief        Run a test on a function and update the test results
+     * \param[in]    testName          - name of the test
+     * \param[in]    functionToCall    - function to call
+     * \param[in]    functionParamValue - parameter value for the function
+     * \param[in]    regToRead         - register to read the result from
+     * \param[in]    expectedResult     - expected result from the register
+     * \param[in]    expectedSuccess    - expected success of the function call
+     * 
+     * \retval       true if the test passed, false otherwise
+     */
+    bool RUN_TEST(const String testName, Func functionToCall, ParamType functionParamValue,
+        uint8_t regToRead, uint8_t expectedResult, bool expectedSuccess = true){
+        uint8_t testingReg;
+        bool functionRes = functionToCall(functionParamValue);
+        if (!functionRes && expectedSuccess) {
+            Serial.println("Setting " + testName + " failed. Function call failed.");
+            return false;
+        }
+        maxim_max30102_read_reg(regToRead, &testingReg);
+        if (testingReg != expectedResult) {
+            Serial.println("Setting " + testName + " failed. Expected: " + String(expectedResult, HEX) + ", got: " + String(testingReg, HEX));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * \brief        Run a function (test) with parameters and update the test results
+     */
+    #define RUN_TEST(...) (RUN_TEST(__VA_ARGS__) ? passedTests++ : failedTests++)
+} 
+
+bool testerSetter(){
+    //uint8_t testingReg;
+    int failedTests = 0;
+    int passedTests = 0;
+
+    // Interrupt Enable 1
+    maxim_max30102_write_reg(REG_INTR_ENABLE_1, 0x00); // FIFO_CONFIG[7:0]
+    RUN_TEST("interruptAFull True", interruptAFull, true, REG_INTR_ENABLE_1, 0x80);
+    RUN_TEST("interruptAFull True", interruptAFull, true, REG_INTR_ENABLE_1, 0x80);
+    RUN_TEST("interruptAFull False", interruptAFull, false, REG_INTR_ENABLE_1, 0x00);
+    RUN_TEST("interruptPPGReady True", interruptPPGReady, true, REG_INTR_ENABLE_1, 0x40);
+    RUN_TEST("interruptPPGReady False", interruptPPGReady, false, REG_INTR_ENABLE_1, 0x00);
+    RUN_TEST("interruptALCOverflow True", interruptALCOverflow, true, REG_INTR_ENABLE_1, 0x20);
+    RUN_TEST("interruptALCOverflow False", interruptALCOverflow, false, REG_INTR_ENABLE_1, 0x00);
+
+    interruptAFull(true);
+    interruptPPGReady(true);
+    RUN_TEST("multipleInter True", interruptALCOverflow, true, REG_INTR_ENABLE_1, 0xE0);
+    RUN_TEST("removingInterruptAFull", interruptAFull, false, REG_INTR_ENABLE_1, 0x60);
+
+    // Interrupt Enable 2
+    maxim_max30102_write_reg(REG_INTR_ENABLE_2, 0x00);
+    RUN_TEST("interruptDIETempReady True", interruptDIETempReady, true, REG_INTR_ENABLE_2, 0x02);
+    RUN_TEST("interruptDIETempReady False", interruptDIETempReady, false, REG_INTR_ENABLE_2, 0x00);
+
+    // Mode Configuration
+    RUN_TEST("setModeControl MULTI_LED", setModeControl, ModeControl::MULTI_LED, REG_MODE_CONFIG, 0x07);
+    RUN_TEST("setModeControl SPO2", setModeControl, ModeControl::SPO2, REG_MODE_CONFIG, 0x03);
+    RUN_TEST("setModeControl HEART_RATE", setModeControl, ModeControl::HEART_RATE, REG_MODE_CONFIG, 0x02);
+
+    // FIFO Write Pointer
+    maxim_max30102_write_reg(REG_FIFO_WR_PTR, 0x00);
+    RUN_TEST("setFifoWritePointer 0x00", setFifoWritePointer, 0x00, REG_FIFO_WR_PTR, 0x00);
+    RUN_TEST("setFifoWritePointer 0x1F", setFifoWritePointer, 0x1F, REG_FIFO_WR_PTR, 0x1F);
+    RUN_TEST("setFifoWritePointer 0x20 (saturates to 0x1F. Function call should fail!)", setFifoWritePointer, 0x20, REG_FIFO_WR_PTR, 0x1F, false);
+    RUN_TEST("setFifoWritePointer 0x00 again", setFifoWritePointer, 0x00, REG_FIFO_WR_PTR, 0x00);
+
+    // FIFO Overflow Counter
+    maxim_max30102_write_reg(REG_OVF_COUNTER, 0x00);
+    RUN_TEST("setFifoOverflowCounter 0x00", setFifoOverflowCounter, 0x00, REG_OVF_COUNTER, 0x00);
+
+    // FIFO Read Pointer
+    maxim_max30102_write_reg(REG_FIFO_RD_PTR, 0x00);
+    RUN_TEST("setFifoReadPointer 0x00", setFifoReadPointer, 0x00, REG_FIFO_RD_PTR, 0x00);
+    RUN_TEST("setFifoReadPointer 0x1F", setFifoReadPointer, 0x1F, REG_FIFO_RD_PTR, 0x1F);
+    RUN_TEST("setFifoReadPointer 0x20 (saturates to 0x1F. Function call should fail!)", setFifoReadPointer, 0x20, REG_FIFO_RD_PTR, 0x1F, false);
+
+    // FIFO Configuration
+    maxim_max30102_write_reg(REG_FIFO_CONFIG, 0x00);
+    RUN_TEST("SampleAveraging NO_AVERAGING", setSampleAveraging, SampleAveraging::NO_AVERAGING, REG_FIFO_CONFIG, 0x00);
+    RUN_TEST("SampleAveraging AVG_2", setSampleAveraging, SampleAveraging::AVG_2, REG_FIFO_CONFIG, 0x20);
+    RUN_TEST("SampleAveraging AVG_4", setSampleAveraging, SampleAveraging::AVG_4, REG_FIFO_CONFIG, 0x40);
+    RUN_TEST("FIFO RollOver Enabled", setFifoRollOverOnFull, true, REG_FIFO_CONFIG, 0x50);
+    RUN_TEST("FIFO RollOver Disabled", setFifoRollOverOnFull, false, REG_FIFO_CONFIG, 0x40);
+    RUN_TEST("FIFO Almost Full Threshold 0x00", setFifoAlmostFullThreshold, 0x00, REG_FIFO_CONFIG, 0x40);
+    RUN_TEST("FIFO Almost Full Threshold 0x0F", setFifoAlmostFullThreshold, 0x0F, REG_FIFO_CONFIG, 0x4F);
+
+    // SpO2 Configuration
+    maxim_max30102_write_reg(REG_SPO2_CONFIG, 0x00);
+    RUN_TEST("SPO2 ADC_RANGE_2048", setSPO2ADCRange, SPO2_ADC_Range::ADC_RANGE_2048, REG_SPO2_CONFIG, 0x00);
+    RUN_TEST("SPO2 ADC_RANGE_4096", setSPO2ADCRange, SPO2_ADC_Range::ADC_RANGE_4096, REG_SPO2_CONFIG, 0x20);
+    RUN_TEST("SPO2 ADC_RANGE_8192", setSPO2ADCRange, SPO2_ADC_Range::ADC_RANGE_8192, REG_SPO2_CONFIG, 0x40);
+    RUN_TEST("SPO2 ADC_RANGE_16384", setSPO2ADCRange, SPO2_ADC_Range::ADC_RANGE_16384, REG_SPO2_CONFIG, 0x60);
+
+    maxim_max30102_write_reg(REG_SPO2_CONFIG, 0x00);
+    RUN_TEST("SPO2 SampleRate 50Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_50, REG_SPO2_CONFIG, 0x00);
+    RUN_TEST("SPO2 SampleRate 100Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_100, REG_SPO2_CONFIG, 0x04);
+    RUN_TEST("SPO2 SampleRate 200Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_200, REG_SPO2_CONFIG, 0x08);
+    RUN_TEST("SPO2 SampleRate 400Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_400, REG_SPO2_CONFIG, 0x0C);
+    RUN_TEST("SPO2 SampleRate 800Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_800, REG_SPO2_CONFIG, 0x10);
+    RUN_TEST("SPO2 SampleRate 1000Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_1000, REG_SPO2_CONFIG, 0x14);
+    RUN_TEST("SPO2 SampleRate 1600Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_1600, REG_SPO2_CONFIG, 0x18);
+    RUN_TEST("SPO2 SampleRate 3200Hz", setSPO2SampleRate, SPO2_SampleRate::SPO2_RATE_3200, REG_SPO2_CONFIG, 0x1C);
+
+    maxim_max30102_write_reg(REG_SPO2_CONFIG, 0x00);
+    RUN_TEST("SPO2 PulseWidth 69us", setSPO2PulseWidth, SPO2_PulseWidth::PW_69, REG_SPO2_CONFIG, 0x00);
+    RUN_TEST("SPO2 PulseWidth 118us", setSPO2PulseWidth, SPO2_PulseWidth::PW_118, REG_SPO2_CONFIG, 0x01);
+    RUN_TEST("SPO2 PulseWidth 215us", setSPO2PulseWidth, SPO2_PulseWidth::PW_215, REG_SPO2_CONFIG, 0x02);
+    RUN_TEST("SPO2 PulseWidth 411us", setSPO2PulseWidth, SPO2_PulseWidth::PW_411, REG_SPO2_CONFIG, 0x03);
+
+    // LED Configuration
+    RUN_TEST("LED1 Pulse Amplitude 0x00", setLED1PulseAmplitude, 0x00, REG_LED1_PA, 0x00);
+    RUN_TEST("LED1 Pulse Amplitude 0xFF", setLED1PulseAmplitude, 0xFF, REG_LED1_PA, 0xFF);
+    RUN_TEST("LED2 Pulse Amplitude 0x00", setLED2PulseAmplitude, 0x00, REG_LED2_PA, 0x00);
+    RUN_TEST("LED2 Pulse Amplitude 0xFF", setLED2PulseAmplitude, 0xFF, REG_LED2_PA, 0xFF);
+
+
+    Serial.println("Total tests: " + String(passedTests + failedTests) + "\nPassed: " + String(passedTests) + "\nFailed: " + String(failedTests));
+    return true;
+}   


### PR DESCRIPTION
## Overview
This PR introduces a new MAX30102 settings helper (`max30102_settings.h` / `max30102_settings.cpp`) to simplify and standardize register configuration. 

It provides:
- **Type‑safe** enums for multi‑bit fields (sample averaging, mode selection, SpO₂ ADC range/sample rate/pulse width)
- **High‑level setters** for all key registers:
  - Interrupt enables (A_FULL, PPG_RDY, ALC_OVF, DIE_TEMP_RDY)
  - FIFO pointers and configuration (write pointer, read pointer, overflow counter, sample averaging, rollover, almost‑full threshold)
  - Mode control (shutdown, reset, mode selection)
  - SpO₂ configuration (ADC range, sample rate, pulse width)
  - LED pulse amplitudes (Red, IR)
  - Temperature measurement enable

## What’s Inside
- Internal bit‑manipulation helpers (alterBitValue, setBitsInField, checkValueInMask) hidden via an anonymous namespace to avoid global symbol pollution
- changeRegMaskValue() with optional mask/value validation
- Individual, descriptive API functions (e.g. setSPO2SampleRate(), interruptAFull(), setFifoWritePointer()) that wrap raw I²C reads/writes
- Built‑in guardrails (mask checking, value saturation) to prevent invalid register writes

## Benefits
- Eliminates manual bit twiddling and magic constants in user code
- Provides compile‑time safety on multi‑bit fields via enum class
- Improves readability and maintainability of MAX30102 integration

## Migration
Simply include max30102_settings.h alongside max30102.h, call the new setter functions in your init sequence, and remove any ad‑hoc bitwise register writes.


_Thank you for considering this enhancement! Feedback and suggestions welcome before merge._

P.S: Been removed some unused variables inside `algorithm.cpp`